### PR TITLE
General: Allow newer PHPMailer versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "require": {
     "php": ">=8.1",
-    "phpmailer/phpmailer": "~6.9",
+    "phpmailer/phpmailer": "~6.9|~7.0",
     "lunr/ticks": "~0.12.0"
   },
   "require-dev": {


### PR DESCRIPTION
Apparently 6.9 causes a phpstan issue now. We can't drop it in the stable branch, but we can relax it to allow newer version that don't have that problem. 7.0 is already allowed on master, that's why there is no problem there.